### PR TITLE
Limit suggested Flatpak override

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This addon is included into the [Linux Addon Repository](https://github.com/wast
 ## Flatpak
 If Kodi had been installed from flatpak, additional access rights have to be granted to the the Kodi sandbox for the addon to work correctly.
 
-	sudo flatpak override --socket=session-bus tv.kodi.Kodi
+	flatpak override --user --own-name=org.mpris.MediaPlayer2.kodi tv.kodi.Kodi
 
 ## Testing via command line
 


### PR DESCRIPTION
Thank you for this essential add-on! Regarding Flatpak permissions, I suggest limiting the proposed override only to Kodi's MPRIS namespace, there's no need to allow full access to the session bus.