### PR TITLE
Tweak for Flatpak permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ It forwards the desktop- and keyboard multimedia control events to Kodi and prov
 
 This addon is included into the [Linux Addon Repository](https://github.com/wastis/LinuxAddonRepo). It is recommended to use the repository for the installation of the addon. This will ease version upgrades. 
 
-## Flatpak
-If Kodi had been installed from flatpak, additional access rights have to be granted to the the Kodi sandbox for the addon to work correctly.
-
-	flatpak override --user --own-name=org.mpris.MediaPlayer2.kodi tv.kodi.Kodi
-
 ## Testing via command line
 
 For simple command line control of Kodi the tool playerctl can be used. 

--- a/resources/lib/mpris.py
+++ b/resources/lib/mpris.py
@@ -50,7 +50,7 @@ class Mpris():
 	def run(self):
 		log("setup event loop")
 
-		mpris_bus_name = "org.mpris.MediaPlayer2.kodi"
+		mpris_bus_name = "org.mpris.MediaPlayer2.tv.kodi.Kodi"
 
 		try:
 			bus = ravel.session_bus()


### PR DESCRIPTION
According to [Flatpak documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html#d-bus-access), using the app-id for the mpris bus name does not require extra permissions or overrides.

This change has no drawbacks for native packages, but allows the addon to work with the official Flatpak with no overrides.

I confirmed that the add-on requires no Flatpak overrides on my PC.